### PR TITLE
Update Toastify to 1.7.3, comply with 1.7.0's review requests.

### DIFF
--- a/toastify/toastify.nuspec
+++ b/toastify/toastify.nuspec
@@ -14,7 +14,7 @@
    <copyright></copyright>
    <licenseUrl>https://toastify.codeplex.com/license</licenseUrl>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-   <iconUrl>http://i.imgur.com/1saQmn2.png</iconUrl>
+   <iconUrl>https://cdn.rawgit.com/TomOne/various/ca0a5f1872bc0fb738e04e2d4d0e505505d23353/toastify.png</iconUrl>
    <dependencies>
      <dependency id="spotify" version="0.9.8.296" />
    </dependencies>

--- a/toastify/toastify.nuspec
+++ b/toastify/toastify.nuspec
@@ -4,7 +4,7 @@
   <metadata>
    <id>toastify</id>
    <title>toastify</title>
-   <version>1.7.0</version>
+   <version>1.7.3</version>
    <authors>Geoffrey Huntley</authors>
    <owners>ghuntley</owners>
    <summary>Toastify adds some missing functionallity to the Spotify client.</summary>
@@ -18,10 +18,19 @@
    <dependencies>
      <dependency id="spotify" version="0.9.8.296" />
    </dependencies>
-   <releaseNotes>- add option to suppress the "launch Spotify?" dialog.
-- recompile so that hopefully Toastify is no longer marked as a generic trojan by Kasperspky
-- Handled a bunch of edge cases in the Spotify album art retriever so you should be seeing more album art!
-- There is now an option to control only Spotify's volume through the hotkeys. This doesn't change the volume in the client (Spotify doesn't support that) but it will change the Windows Audio Mixer volume for Spotify, achieving a similar result. By default this is off to avoid potential confusion from users who are adjusting the volume of Spotify through Toastify and the client/system and don't know about the mixer.</releaseNotes>
+   <releaseNotes>
+    # Toastify 1.7.2
+
+    - Corrected version (bug #13508)
+    - Added support for Win key in hotkeys (thanks bwp11!)
+
+    # Toastify 1.7.1
+
+    - Support for Spotify v1
+      - This support is much more invasive than previous versions due to changes made by Spotify (primarily the removal of the Artist / Track from the title bar). It has some benefits, but also comes with some down sides (we must restart Spotify when launching Toastify). There will also be bugs.
+    - Support for Toast positioning on high-DPI screens, you may need to re-position your Toasts
+
+  </releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/toastify/tools/chocolateyInstall.ps1
+++ b/toastify/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = 'toastify' # arbitrary name for the package, used in messages
 $installerType = 'EXE' #only one of these: exe, msi, msu
-$url = 'https://toastify.codeplex.com/downloads/get/960495' # download url
-$url64 = 'https://toastify.codeplex.com/downloads/get/960495' # 64bit URL here or remove - if installer decides, then use $url
+$url = 'https://toastify.codeplex.com/downloads/get/1440002' # download url
+$url64 = 'https://toastify.codeplex.com/downloads/get/1440002' # 64bit URL here or remove - if installer decides, then use $url
 $silentArgs = '/S' # "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT" # try any of these to get the silent installer #msi is always /quiet
 $validExitCodes = @(0) #please insert other valid exit codes here, exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
 

--- a/toastify/tools/chocolateyInstall.ps1
+++ b/toastify/tools/chocolateyInstall.ps1
@@ -1,50 +1,8 @@
-﻿#NOTE: Please remove any commented lines to tidy up prior to releasing the package, including this one
+﻿$packageName = 'toastify'
+$installerType = 'EXE' 
+$url = 'https://toastify.codeplex.com/downloads/get/1440002' 
+$url64 = 'https://toastify.codeplex.com/downloads/get/1440002'
+$silentArgs = '/S' 
+$validExitCodes = @(0)
 
-$packageName = 'toastify' # arbitrary name for the package, used in messages
-$installerType = 'EXE' #only one of these: exe, msi, msu
-$url = 'https://toastify.codeplex.com/downloads/get/1440002' # download url
-$url64 = 'https://toastify.codeplex.com/downloads/get/1440002' # 64bit URL here or remove - if installer decides, then use $url
-$silentArgs = '/S' # "/s /S /q /Q /quiet /silent /SILENT /VERYSILENT" # try any of these to get the silent installer #msi is always /quiet
-$validExitCodes = @(0) #please insert other valid exit codes here, exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
-
-# main helpers - these have error handling tucked into them already
-# installer, will assert administrative rights
-
-# if removing $url64, please remove from here
 Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64"  -validExitCodes $validExitCodes
-# download and unpack a zip file
-
-# if removing $url64, please remove from here
-#Install-ChocolateyZipPackage "$packageName" "$url" "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" "$url64"
-
-#try { #error handling is only necessary if you need to do anything in addition to/instead of the main helpers
-  # other helpers - using any of these means you want to uncomment the error handling up top and at bottom.
-  # downloader that the main helpers use to download items
-
-  # if removing $url64, please remove from here
-  #Get-ChocolateyWebFile "$packageName" 'DOWNLOAD_TO_FILE_FULL_PATH' "$url" "$url64"
-  # installer, will assert administrative rights - used by Install-ChocolateyPackage
-  #Install-ChocolateyInstallPackage "$packageName" "$installerType" "$silentArgs" '_FULLFILEPATH_' -validExitCodes $validExitCodes
-  # unzips a file to the specified location - auto overwrites existing content
-  #Get-ChocolateyUnzip "FULL_LOCATION_TO_ZIP.zip" "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-  # Runs processes asserting UAC, will assert administrative rights - used by Install-ChocolateyInstallPackage
-  #Start-ChocolateyProcessAsAdmin 'STATEMENTS_TO_RUN' 'Optional_Application_If_Not_PowerShell' -validExitCodes $validExitCodes
-  # add specific folders to the path - any executables found in the chocolatey package folder will already be on the path. This is used in addition to that or for cases when a native installer doesn't add things to the path.
-  #Install-ChocolateyPath 'LOCATION_TO_ADD_TO_PATH' 'User_OR_Machine' # Machine will assert administrative rights
-  # add specific files as shortcuts to the desktop
-  #$target = Join-Path $MyInvocation.MyCommand.Definition "$($packageName).exe"
-  #Install-ChocolateyDesktopLink $target
-
-  #------- ADDITIONAL SETUP -------#
-  # make sure to uncomment the error handling if you have additional setup to do
-
-  #$processor = Get-WmiObject Win32_Processor
-  #$is64bit = $processor.AddressWidth -eq 64
-
-
-  # the following is all part of error handling
-  #Write-ChocolateySuccess "$packageName"
-#} catch {
-  #Write-ChocolateyFailure "$packageName" "$($_.Exception.Message)"
-  #throw
-#}


### PR DESCRIPTION
I've updated the Toastify package to download 1.7.3 (just realised the commit says "1.7.2" - oops!), as well as included the latest changelogs since 1.7.0; there isn't one on the CodePlex site for 1.7.3 itself.

I also went and changed the package logo URL to use the Toastify icon, and removed all the comments in the installation script - both of these were requested in the review for 1.7.0.
